### PR TITLE
commit for internal review

### DIFF
--- a/schemata_python/seshat_instances.py
+++ b/schemata_python/seshat_instances.py
@@ -118,21 +118,21 @@ class Duration(ScopedValue, GeneralInfo):
     _subdocument = []
     duration: 'GYearRange'
 
-class Territory(SocialComplexity):
+class TerritoryValue(SocialComplexity):
     _schema = seshat_schema
     label = 'Polity territory'
     _subdocument = []
     territory_range: DecimalRange
     territory_date:' ScopedValue'
 
-class ProfessionalMilitary(Military):
+class ProfessionalMilitaryValue(Military):
     _schema = seshat_schema
     label = 'Professional military'
     _subdocument = []
     epistemic_state: 'EpistemicState'
     scope: 'ScopedValue'
 
-class AdministrativeLevel(Politics):
+class AdministrativeLevelValue(Politics):
     _schema = seshat_schema
     label = 'Administrative level'
     _subdocument = []
@@ -140,19 +140,22 @@ class AdministrativeLevel(Politics):
     disputed: 'ScopedValue'
     value: int
 
-class DisputedValuesTerritory(DocumentTemplate):
+class Territory(DocumentTemplate):
     _schema = seshat_schema
     _subdocument = []
-    territory_1: 'Territory'
-    territory_2: Optional['Territory']
-    territory_3: Optional['Territory']
+    territory: List['TerritoryValue']
 
-class DisputedValuesAdmin(DocumentTemplate):
+class AdministrativeLevels(DocumentTemplate):
     _schema = seshat_schema
     _subdocument = []
-    admin_1: 'AdministrativeLevel'
-    admin_2: Optional['AdministrativeLevel']
-    admin_3: Optional['AdministrativeLevel']
+    administrative_levels: List['AdministrativeLevelValue']
+
+# is professional military likely to have more than one values?
+# if not there is no need for a list.
+class ProfessionalMilitary(DocumentTemplate):
+    _schema = seshat_schema
+    _subdocument = []
+    administrative_levels: List['ProfessionalMilitaryValue']
 
 # TODO Need an example to inherit from Legal subsection
 # Define properties with a property scoped value or a Set[property scoped value] if uncertainty [] is allowed
@@ -168,9 +171,7 @@ class Polity(DocumentTemplate):
     duration: 'Duration'
     territory: 'Territory'
     professional_military: 'ProfessionalMilitary'
-    administrative_level: 'Administrative_level'
-    disputed_territory_values: 'DisputedValuesTerritory'
-    disputed_admin_level_values: 'DisputedValuesAdmin'
+    admin_levels: 'AdministrativeLevels'
 
 
 
@@ -187,38 +188,41 @@ p_d.peak_date = 1761
 dur = Duration()
 dur.duration = [1741,1826]
 
-territory_1 = Territory(territory_range=[60000,80000], territory_date=1772)
-territory_2 = Territory(territory_range=[179000,490000], territory_date=1800)
+territory_1 = TerritoryValue()
+territory_1.territory_range = [60000,80000]
+territory_1.territory_date = 1772
 
-disputed_territory = DisputedValuesTerritory()
-disputed_territory.territory_1 = territory_1
-disputed_territory.territory_2 = territory_2
+territory_2 = TerritoryValue()
+territory_2.territory_range = [179000,490000]
+territory_2.territory_date = 1800
+
+territory_list = Territory()
+territory_list.territory = [territory_1, territory_2]
 
 
 section = ScopedValue().inferred
 section = True
 
-professional_military_1 = ProfessionalMilitary(epistemic_state=EpistemicState.present,
+professional_military_1 = ProfessionalMilitaryValue(epistemic_state=EpistemicState.present,
                                                scope=section)
 
-adm_scoped_dispute_1 = ScopedValue().disputed
-adm_scoped_dispute_1 = True
-adm_level1 = AdministrativeLevel(value=4, dates=1800, disputed=adm_scoped_dispute_1)
+professional_military_list = [professional_military_1]
 
-adm_scoped_dispute_2 = ScopedValue().disputed
-adm_scoped_dispute_2 = True
-adm_level2 = AdministrativeLevel(value=5, dates=1800, disputed=adm_scoped_dispute_1)
+adm_scoped_dispute_true = ScopedValue().disputed
+adm_scoped_dispute_true = True
 
-disputed_admin_level = DisputedValuesAdmin()
-disputed_admin_level.admin_1 = adm_level1
-disputed_admin_level.admin_2 = adm_level2
+adm_level1 = AdministrativeLevelValue(value=4, dates=1800, disputed=adm_scoped_dispute_true)
+adm_level2 = AdministrativeLevelValue(value=5, dates=1800, disputed=adm_scoped_dispute_true)
+
+admin_level_list = AdministrativeLevels()
+admin_level_list.administrative_levels = [adm_level1, adm_level2]
 
 
 afdurn = Polity(polid='af_durn',originalID='Afdurrn',
                 peak_date=p_d, duration=dur,
-                disputed_territory_values=disputed_territory,
+                territory=territory_list,
                 professional_military=professional_military_1,
-                disputed_admin_level_values = disputed_admin_level)
+                admin_levels = admin_level_list)
 
 pp.pprint(afdurn._obj_to_dict())
 

--- a/schemata_python/seshat_instances.py
+++ b/schemata_python/seshat_instances.py
@@ -3,29 +3,54 @@ from terminusdb_client.woqlschema.woql_schema import (
     DocumentTemplate,
     EnumTemplate,
     HashKey,
-    TaggedUnion, # an 'enum'
+    TaggedUnion, # a disjunction
     WOQLSchema,
 )
 
+from enum import Enum
 from terminusdb_client.woqlclient.woqlClient import WOQLClient
 import pprint as pp
 import sys
-
 seshat_schema = WOQLSchema()
-# first define ScopedValue classes and associated enums for Polity properties
-# useful enums
-class enum_EpistemicState(EnumTemplate):
+
+class EpistemicState(EnumTemplate):
+    '''Enumeration Type'''
     _schema = seshat_schema
     absent = ()
     absent_to_present = ()
     present = ()
     present_to_absent = ()
-# Dan points out that there are some other residual possible enumerations around bureaucracy etc
-# ('direct', 'widespread', 'infrequent', etc.) but that these will all be converted to present/absent
-# and recoded on the wiki before transfer.  So EpistemicState is likely our only data enum
+
+# ... define all the rest of the types from boxed_basic_types list
+
+
+class IntegerRange(DocumentTemplate):
+    '''A simple number or range of integers'''
+    _schema = seshat_schema
+    integer_range: Set[int]
+
+class DecimalRange(DocumentTemplate):
+    '''Decimal number range'''
+    _schema = seshat_schema
+    decimal_range: Set[float]
+
+class GYear(DocumentTemplate):
+    '''A particular Gregorian 4 digit year YYYY - negative years are BCE'''
+    _schema = seshat_schema
+    g_year: int
+
+class GYearRange(DocumentTemplate):
+    '''A 4-digit Gregorian year, YYYY, or if uncertain, a range of years [YYYY,YYYY]'''
+    _schema = seshat_schema
+    g_year_range: Set[int]
+
+class Boolean(Enum):
+    _schema = seshat_schema
+    value: bool
+
 class ScopedValue(DocumentTemplate):
     _schema = seshat_schema
-    dates = 'xsd:gYearRange' # dates to restrict the value to... e.g., Foo: 134BCE-200CE
+    dates: 'GYearRange' # dates to restrict the value to... e.g., Foo: 134BCE-200CE
     # Confidence qualifiers
     # Semantics: if unknown is True then there will/must be no value set on the BoxedType tagged union
     # If unknown is True, suspected could be set True if it was supplied by an RA
@@ -34,44 +59,13 @@ class ScopedValue(DocumentTemplate):
     # 1) no unknown or suspected property,
     # 2) one of the BoxedType properties
     # 3) optionally one or both of disputed or inferred set
-    unknown   = 'xsd:boolean' # is the (typed) value explicitly unknown?
-    suspected = 'xsd:boolean' # is the value (typically unknown) provided by an RA versus an expert
-    disputed  = 'xsd:boolean' # is this one of several disputed values {}?
-    inferred  = 'xsd:boolean' # is the value inferred somehow?
+    unknown:  bool # is the (typed) value explicitly unknown?
+    suspected: bool # is the value (typically unknown) provided by an RA versus an expert
+    disputed: bool # is this one of several disputed values {}?
+    inferred: bool # is the value inferred somehow?
 # Type mixins (boxed classes) for property ScopedValues
 # TODO verify capitalization of property names and types
-class EpistemicState(DocumentTemplate):
-    _schema = seshat_schema
-    epistemic_state: enum_EpistemicState
-class String(DocumentTemplate):
-    '''Any text or sequence of characters'''
-    _schema = seshat_schema
-    string: 'xsd:string' # or str?
-class Integer(DocumentTemplate):
-    '''A simple number'''
-    _schema = seshat_schema
-    integer: 'xsd:integer'
-class IntegerRange(DocumentTemplate):
-    '''A simple number or range of integers'''
-    _schema = seshat_schema
-    integer_range: 'xsd:integerRange'
-class Decimal(DocumentTemplate):
-    '''A decimal number'''
-    _schema = seshat_schema
-    decimal: 'xsd:decimal'
-class DecimalRange(DocumentTemplate):
-    '''A decimal number'''
-    _schema = seshat_schema
-    decimal_range: 'xsd:decimalRange'
-class GYear(DocumentTemplate):
-    '''A particular Gregorian 4 digit year YYYY - negative years are BCE'''
-    _schema = seshat_schema
-    gYear: 'xsd:gYear'
-class GYearRange(DocumentTemplate):
-    '''A 4-digit Gregorian year, YYYY, or if uncertain, a range of years [YYYY,YYYY]'''
-    _schema = seshat_schema
-    gYearRange: 'xdd:gYearRange'
-# ... define all the rest of the types from boxed_basic_types list
+
 # Define example topic Section/Subsection classes (no properties on these)
 class Topic(DocumentTemplate):
     '''Root of topic hierarchy'''
@@ -85,87 +79,149 @@ class SocialComplexity(Topic):
     '''Social Complexity variables'''
     _schema = seshat_schema
     _abstract = []
+
 class Military(Topic):
    '''Miltiary variables'''
    _schema = seshat_schema
    _abstract = []
+
 class Politics(Topic):
     '''Political variables'''
     _schema = seshat_schema
     _abstract = []
 # A subsection
+
 class Legal(Politics): # Inherit from Politics as a subsection, not DocumentTemplate
     '''Legal system variables'''
     _schema = seshat_schema
     _abstract = []
+
 # NOTE: label will be used to parse from csv file strings to the proper class types
 # and for pretty display on the website
 # JSB? How do we declare instances with random gensym for names?  How to specify/override @key?
 # Note: our look-aside dicts would maintain information that the 'Peak data' Variable from a csv file
+
 # would map to the 'peak_date' property on a Polity
 # and that its BoxedType property (on the ScopedValue value instance) is gYearRange
 # which requires a (possibly reformed) ValueTo csv string that can be cast to a 'xdd:gYearRange'
-class PeakDate(ScopedValue, GYearRange, GeneralInfo):
+
+class PeakDate(DocumentTemplate):
     _schema = seshat_schema
     label = 'Peak date'
     # Format of _subdocument for each seshat property is ScopedValue, then a boxed type, then one or more Topics
     _subdocument = []
-class Duration(ScopedValue, GYearRange, GeneralInfo):
+    peak_date: int
+
+class Duration(ScopedValue, GeneralInfo):
     _schema = seshat_schema
     label = 'Duration'
     _subdocument = []
-class Territory(ScopedValue, DecimalRange, SocialComplexity):
+    duration: 'GYearRange'
+
+class Territory(SocialComplexity):
     _schema = seshat_schema
     label = 'Polity territory'
     _subdocument = []
-class ProfessionalMilitary(ScopedValue, EpistemicState, Military): 
+    territory_range: DecimalRange
+    territory_date:' ScopedValue'
+
+class ProfessionalMilitary(Military):
     _schema = seshat_schema
     label = 'Professional military'
     _subdocument = []
-# Note singleton name
-class Administrative_level(ScopedValue, IntegerRange, Politics):
+    epistemic_state: 'EpistemicState'
+    scope: 'ScopedValue'
+
+class AdministrativeLevel(Politics):
     _schema = seshat_schema
     label = 'Administrative level'
     _subdocument = []
+    dates: 'GYear'
+    disputed: 'ScopedValue'
+    value: int
+
+class DisputedValuesTerritory(DocumentTemplate):
+    _schema = seshat_schema
+    _subdocument = []
+    territory_1: 'Territory'
+    territory_2: Optional['Territory']
+    territory_3: Optional['Territory']
+
+class DisputedValuesAdmin(DocumentTemplate):
+    _schema = seshat_schema
+    _subdocument = []
+    admin_1: 'AdministrativeLevel'
+    admin_2: Optional['AdministrativeLevel']
+    admin_3: Optional['AdministrativeLevel']
+
 # TODO Need an example to inherit from Legal subsection
 # Define properties with a property scoped value or a Set[property scoped value] if uncertainty [] is allowed
 # marshall values back and forth?
 # tuple of Year elements e.g. range
+
 class Polity(DocumentTemplate):
     _schema = seshat_schema
     polid: str # the equivalent of 'label'?  JSB? Note use of str, not 'xsd:string'?
     originalID: str # to compare with the old wiki polity page names
     # in order to permit uncertain or disputed values with different dates all seshat properties are Set[]
-    peak_date: Set[PeakDate] # typically only one but could be disputed
-    duration: Set[Duration]
-    territory: Set[Territory]
-    professional_military: Set[ProfessionalMilitary]
-    administrative_level: Set[Administrative_level]
+    peak_date:'PeakDate' # typically only one but could be disputed
+    duration: 'Duration'
+    territory: 'Territory'
+    professional_military: 'ProfessionalMilitary'
+    administrative_level: 'Administrative_level'
+    disputed_territory_values: 'DisputedValuesTerritory'
+    disputed_admin_level_values: 'DisputedValuesAdmin'
+
+
+
 # define an example instance from our powerpoint slide (slide 7)
 # in fact, we'll generate these by parsing the csv file and then constructing or updating a JSON object
 # so no use? of the Python constructors with arguments?
 # We will be building up a document instance 'patch' (or fetching and patching the whole instance)
 # Need to mock this up using our python dictionary scheme...
 # These are all instances of some ScopedValue class
-peak_date_1 = PeakDate(Date='1761') #string or integer?
-# e.g., 1741-1826CE
-duration_1 = Duration(DateRange='[1741,1826]') #string or integer?
-# e.g., [60000,80000]:1772; [179000,490000]:1800
-territory_1 = Territory(DecimalRange='[60000,80000]',dates='1772')
-territory_2 = Territory(DecimalRange='[179000,490000]',dates='1800')
-# e.g., inferred present
-professional_military_1 = ProfessionalMilitary(EpistemicState=enum_EpistemicState.present,inferred=True)
-# a made up example to test disputed,
-# e.g, {4:1800; 5:1800}
-adm_level1 = Administrative_level(nonNegativeInteger='4',dates='1800',disputed=True)
-adm_level2 = Administrative_level(nonNegativeInteger='5',dates='1800',disputed=True)
+
+p_d = PeakDate()
+p_d.peak_date = 1761
+
+dur = Duration()
+dur.duration = [1741,1826]
+
+territory_1 = Territory(territory_range=[60000,80000], territory_date=1772)
+territory_2 = Territory(territory_range=[179000,490000], territory_date=1800)
+
+disputed_territory = DisputedValuesTerritory()
+disputed_territory.territory_1 = territory_1
+disputed_territory.territory_2 = territory_2
+
+
+section = ScopedValue().inferred
+section = True
+
+professional_military_1 = ProfessionalMilitary(epistemic_state=EpistemicState.present,
+                                               scope=section)
+
+adm_scoped_dispute_1 = ScopedValue().disputed
+adm_scoped_dispute_1 = True
+adm_level1 = AdministrativeLevel(value=4, dates=1800, disputed=adm_scoped_dispute_1)
+
+adm_scoped_dispute_2 = ScopedValue().disputed
+adm_scoped_dispute_2 = True
+adm_level2 = AdministrativeLevel(value=5, dates=1800, disputed=adm_scoped_dispute_1)
+
+disputed_admin_level = DisputedValuesAdmin()
+disputed_admin_level.admin_1 = adm_level1
+disputed_admin_level.admin_2 = adm_level2
+
+
 afdurn = Polity(polid='af_durn',originalID='Afdurrn',
-                peak_date=[peak_date_1], # are the []'s required for singleton sets?
-                duration=[duration_1],
-                territory=[territory_1,territory_2], # NOTE alternative data values here
-                professional_military=[professional_military_1],
-                administrative_level=[adm_level1,adm_level2] # NOTE a set of disputed values
-                )
+                peak_date=p_d, duration=dur,
+                disputed_territory_values=disputed_territory,
+                professional_military=professional_military_1,
+                disputed_admin_level_values = disputed_admin_level)
+
+pp.pprint(afdurn._obj_to_dict())
+
 client = WOQLClient("http://127.0.0.1:6363/")
 client.connect()
 exists = client.get_database("test_seshat")
@@ -183,7 +239,7 @@ except Exception as E:
     print(E.error_obj)
     sys.exit(1)
 # Add a single instance
-pp.pprint(afdurrn.to_dict()) # report the internal form of the instance
+pp.pprint(afdurn._to_dict()) # report the internal form of the instance
 try:
     client.insert_document(afdurn, commit_msg="Commit Afdurn", graph_type= "instance")
 except Exception as E:


### PR DESCRIPTION
Changes made to the script sent on the 27th ofJuly 2021:

1. classes enum_EpistemicState and EpistemicState were merged to one class. Justification: both classes are document templates, the variables are defined in enum_EpistemicState and then called from the EpistemicState. This is a redundancy. I understand that the naming conversion of enum_EpistemicState is to indicate that the class is an enumeration declaration. To comply with the descriptive nature of this conversion, I added a docstring that describes the class.
Another way to do it is define the enum_EpistemicState class as an Enum (relevant import: from enum import Enum) and not as an EnumTemplate. I don't know if this adds any value.

2. Boxed values definition: moved the definition classes higher up as they will be called frequently from other classes.

3. Boxed values definition: deleted the definition classes: string, integer, and float. They are self explanatory.

4. Boxed values definition: replaced Decimal with float. TerminusClass does not support decimal yet. If the accuracy is critical to the process, please let me know and i will modify the source code.

5. class ScopedValue: dates definition was edited.

6. class ScopedValue: boolean corrected.

7. comment from JSB: How do we declare instances with random gensym for names?  How to specify/override @key?
**DGP: Can we assign random Gensyms as a key? -Ask Gavin**

8. classes PeakDate, Duration, Territory, ProfessionalMilitary: added values, removed unecessary inheritances.

9. class Polity: Removed the Set of classes.

10. I defined Territory as a DocumentTemplate, but I need to make it an object template  so that I can have a list of disputed values. I made a temporary thing (which I don't like): class DisputedValues_Territory. **Should we bring back the ObjectTemplate in woql_schema?**

11. same as above applied to Administrative levels.